### PR TITLE
Fixing exception when controller is not an array

### DIFF
--- a/Listener/ControllerListener.php
+++ b/Listener/ControllerListener.php
@@ -15,7 +15,7 @@ class ControllerListener
         {
             // controller catching    
             $_controller = $event->getController();
-            if (isset($_controller[0])) 
+            if (is_array($_controller) && isset($_controller[0])) 
             {
                 $controller = $_controller[0];
                 // preExecute method verification


### PR DESCRIPTION
Fixing exception : When "getController" (in the FilterControllerEvent) does not return an array

For exemple, when you do this  : 
    $filterControllerEvent->setController(function() { ... } )
